### PR TITLE
fixup: remove reliance on nightly features, fix compiler warnings

### DIFF
--- a/src/fdt/header.rs
+++ b/src/fdt/header.rs
@@ -1,8 +1,4 @@
-use log::{
-    info,
-    debug,
-    error
-};
+use log::debug;
 
 use crate::{
     utils, 
@@ -42,6 +38,32 @@ pub struct FdtHeader {
 }
 
 impl FdtHeader {
+    /// The offset in bytes of the structure block from the beginning of the header.
+    pub const fn off_dt_struct(&self) -> u32 {
+        self.off_dt_struct
+    }
+
+    /// The offset in bytes of the strings block from the beginning of the header.
+    pub const fn off_dt_strings(&self) -> u32 {
+        self.off_dt_strings
+    }
+
+    /// The offset in bytes of the memory reservation block from the beginning of the header.
+    pub const fn off_mem_rsvmap(&self) -> u32 {
+        self.off_mem_rsvmap
+    }
+
+    /// The lowest version of the devicetree data structure with which the version used is backwards compatible.
+    pub const fn last_comp_version(&self) -> u32 {
+        self.last_comp_version
+    }
+
+    /// The physical ID of the system’s boot CPU.
+    /// It shall be identical to the physical ID given in the reg property of that CPU node within the devicetree.
+    pub const fn boot_cpuid_phys(&self) -> u32 {
+        self.boot_cpuid_phys
+    }
+
     pub fn from_bytes(bytes: &mut &[u8]) -> Result<Self, DeviceTreeError> {
         debug!("Parsing FDT header from bytes.");
 

--- a/src/fdt/parsing.rs
+++ b/src/fdt/parsing.rs
@@ -67,11 +67,17 @@ impl<'a> DeviceTreeBlob<'a> {
         let structure_block_size = header.size_dt_struct();
         let string_block_size = header.size_dt_strings();
 
+        let struct_buf = &bytes[..structure_block_size];
+        *bytes = &bytes[structure_block_size..];
+
+        let string_buf = &bytes[..string_block_size];
+        *bytes = &bytes[string_block_size..];
+
         Ok( Self {
             header: header,
             memory_reservation_block: memory_reservation_vec,
-            structure_block: FdtStructBlock::from_bytes(bytes.take(..structure_block_size).unwrap()),
-            strings_block: FdtStringsBlock::from_bytes(bytes.take(..string_block_size).unwrap()) 
+            structure_block: FdtStructBlock::from_bytes(struct_buf),
+            strings_block: FdtStringsBlock::from_bytes(string_buf), 
         })
     }
 

--- a/src/fdt/parsing.rs
+++ b/src/fdt/parsing.rs
@@ -6,7 +6,6 @@ use alloc::{
 use log::{
     info,
     debug,
-    error
 };
 
 use super::header::FdtHeader;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
 #![no_std]
-#![feature(slice_take)]
-#![feature(cstr_from_bytes_until_nul)]
-#![feature(format_args_nl)]
 
 #[cfg_attr(test, macro_use)]
 pub mod tree;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,3 +48,15 @@ pub struct DeviceTreeBlob<'a> {
     structure_block: FdtStructBlock<'a>,
     strings_block: FdtStringsBlock<'a>
 }
+
+impl<'a> DeviceTreeBlob<'a> {
+    /// Gets a reference to the [FdtHeader].
+    pub const fn header(&self) -> &FdtHeader {
+        &self.header
+    }
+
+    /// Gets a reference to the list of [FdtReserveEntry].
+    pub fn memory_reservation_block(&self) -> &[FdtReserveEntry] {
+        self.memory_reservation_block.as_ref()
+    }
+}

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,25 +1,17 @@
 use alloc::{
 	string::{String, ToString},
-	vec::Vec,
 	rc::Rc,
 	collections::{
 		BTreeMap,
-		btree_map::Iter
-	}
+		btree_map::Iter,
+	},
 };
 use core::cell::RefCell;
-use log::{
-    info,
-    debug,
-    error
-};
-
-use crate::{DeviceTreeError, utils};
+use log::debug;
 
 use super::prop::{
 	DeviceTreeProperty,
 	NumCells,
-	Pairs
 };
 
 const INDENT_SIZE: usize = 4;

--- a/src/tree/tree.rs
+++ b/src/tree/tree.rs
@@ -1,18 +1,10 @@
 use alloc::rc::Rc;
 
-use crate::{
-	DeviceTree, 
-	DeviceTreeError
+use crate::DeviceTree;
+use crate::tree::node::{
+	DeviceTreeNodeWrap, 
+	DeviceTreeNode
 };
-use crate::tree::{
-	node::{
-		DeviceTreeNodeWrap, 
-		DeviceTreeNode
-	},
-	prop::DeviceTreeProperty
-};
-
-use super::CPU_MAX_NUM;
 
 impl DeviceTree {
 	pub fn new_empty_root() -> Self {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -79,12 +79,12 @@ pub(crate) fn take_aligned<'a>(input: &mut &'a [u8], len: usize, align: usize) -
 /// A function that compares two enums by their variant
 /// 
 /// Returns true if both enums are same variant
-pub(crate) fn variant_eq<T>(a: &T, b: &T) -> bool {
+pub fn variant_eq<T>(a: &T, b: &T) -> bool {
 	discriminant(a) == discriminant(b)
 }
 
 /// A function that print vector of strings in the form '<String1>', '<String2>'
-pub(crate) fn vec_strings_fmt(v: &Vec<String>) -> String {
+pub fn vec_strings_fmt(v: &Vec<String>) -> String {
 	let v_fmt: Vec<String> = v.iter().map(|i| format!("'{}'", i)).collect();
 
 	v_fmt.join(", ")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,7 +11,13 @@ use alloc::{
 /// 
 /// Returns None and does not modify the slice if the given length is out of bounds.
 pub(crate) fn pop_slice<'a>(input: &mut &'a [u8], len: usize) -> Option<&'a [u8]> {
-    input.take(..len)
+    if len < input.len() {
+        let out = Some(&input[..len]);
+        *input = &input[len..];
+        out
+    } else {
+        None
+    }
 }
 
 /// Read from a slice as a u32 in big endian


### PR DESCRIPTION
Removes nightly features from the library to allow building with a stable toolchain.

No change to user-facing API.

Adds accessor functions for struct fields, and small fixes for compiler warnings about unused imports.